### PR TITLE
Add method getRawChangeAddress

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,6 +152,7 @@ RpcClient.callspec = {
   getAddressDeltas: 'obj',
   getAddressTxids: 'obj',
   getAddressesByAccount: '',
+  getRawChangeAddress: '',
   getBalance: 'str int',
   getBestBlockHash: '',
   getBlock: 'str bool',


### PR DESCRIPTION
I need `getRawChangeAddress` in the lib.
It's available in `qtum-cli` command but not in the lib.
Please help to review and approve this change.